### PR TITLE
downgrade iOS target of the framework to iOS 8 (for Carthage usage)

### DIFF
--- a/Example/DBSphereTagCloud.xcodeproj/project.pbxproj
+++ b/Example/DBSphereTagCloud.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "DBSphereTagCloud-Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onefatgiraffe.DBSphereTagCloud-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -523,7 +523,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "DBSphereTagCloud-Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onefatgiraffe.DBSphereTagCloud-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
The readme states that this library works on iOS 8+. However, when trying to include the`.framework` file via **Carthage**, it's requiring iOS 11+. I've downgraded it again. Seems to be working fine (at least on iOS 10+). Am I missing anything?